### PR TITLE
fix error on button style

### DIFF
--- a/EiDiA_frontend/src/components/Header.js
+++ b/EiDiA_frontend/src/components/Header.js
@@ -60,7 +60,7 @@ const MenuAppBar = (props) => {
                     <div>
                         <IconButton
                             onClick={handleMenu}
-                            color="black"
+                            color="default"
                         >
                             <AccountCircle/>
                         </IconButton>
@@ -80,6 +80,7 @@ const MenuAppBar = (props) => {
                             onClose={handleClose}
                         >
                             <MenuItem onClick={handleClose}>User Account</MenuItem>
+                            <MenuItem onClick={handleClose}>Help</MenuItem>
                             <MenuItem onClick={handleClose}>Logout</MenuItem>
                         </Menu>
                     </div>


### PR DESCRIPTION
Fixes in https://github.com/csehlke/EiDiA/pull/18
```
Warning: Failed prop type: Invalid prop `color` of value `black` supplied to `ForwardRef(IconButton)`, expected one of ["default","inherit","primary","secondary"].
    in ForwardRef(IconButton) (created by WithStyles(ForwardRef(IconButton)))
    in WithStyles(ForwardRef(IconButton)) (created by MenuAppBar)
    in div (created by MenuAppBar)
    in div (created by ForwardRef(Toolbar))
    in ForwardRef(Toolbar) (created by WithStyles(ForwardRef(Toolbar)))
    in WithStyles(ForwardRef(Toolbar)) (created by MenuAppBar)
    in header (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(AppBar))
    in ForwardRef(AppBar) (created by WithStyles(ForwardRef(AppBar)))
    in WithStyles(ForwardRef(AppBar)) (created by MenuAppBar)
    in div (created by MenuAppBar)
    in MenuAppBar (created by Page)
    in section (created by Page)
    in Page (created by SearchView)
    in SearchView (created by Context.Consumer)
    in Route (created by App)
    in Switch (created by App)
    in Router (created by HashRouter)
    in HashRouter (created by App)
    in div (created by App)
    in App
```


![grafik](https://user-images.githubusercontent.com/29836078/83952933-ced82f80-a83c-11ea-9260-91ada360bcbc.png)
